### PR TITLE
Fix genre search count

### DIFF
--- a/mflix/src/main/java/mflix/api/services/MoviesService.java
+++ b/mflix/src/main/java/mflix/api/services/MoviesService.java
@@ -185,7 +185,7 @@ public class MoviesService {
     result.put("movies_list", movieList);
 
     if (page == 0) {
-      result.put("movies_count", movieDao.getCastSearchCount(genres));
+      result.put("movies_count", movieDao.getGenresSearchCount(genres));
     }
     return result;
   }


### PR DESCRIPTION
Fixed copy-paste error in `getMoviesByGenre`, since it used wrong criteria