### PR TITLE
Add year deserialise in movie object

### DIFF
--- a/mflix/src/main/java/mflix/api/daos/MovieDocumentMapper.java
+++ b/mflix/src/main/java/mflix/api/daos/MovieDocumentMapper.java
@@ -34,6 +34,7 @@ public class MovieDocumentMapper {
     try {
       movie.setId(document.getObjectId("_id").toHexString());
       movie.setTitle(MessageFormat.format("{0}", document.get("title")));
+      movie.setYear(document.getInteger("year"));
       movie.setCast((List<String>) document.get("cast"));
       movie.setPlog(document.getString("plot"));
       movie.setFullPlot(document.getString("fullplot"));


### PR DESCRIPTION
Movie object lacks year field on reading from Mongo. This fix makes year visible on UI/ Every document in sample-mflix has it.